### PR TITLE
app/includes/header.tpl: fix "small" version display

### DIFF
--- a/app/includes/header.tpl
+++ b/app/includes/header.tpl
@@ -88,7 +88,7 @@
       <a class="brand" href="/" aria-label="Go to homepage">
         <img src="images/logo-akroma-web-wallet.svg"   height="64px" width="245px" alt="Akroma Web Wallet" />
         <!-- <h1>Akroma Web Wallet</h1> -->
-        <p class="small visible-xs">0.0.1</p>
+        <p class="small visible-xs">3.21.22</p>
       </a>
    
     <div class="tagline">


### PR DESCRIPTION
The mobile version of the web wallet is showing the wrong version
Probably caused by a merge error (oops, my bad)

![](https://pbs.twimg.com/media/DluKQGCUcAA2m_h.jpg)

This should fix it